### PR TITLE
add TypeScript interface for transport API

### DIFF
--- a/interfaces/transport.d.ts
+++ b/interfaces/transport.d.ts
@@ -1,0 +1,27 @@
+/**
+ * For a description of each method and event, see
+ * freedom/interface/transport.js in the Freedom source.
+ */
+
+/// <reference path='promise.d.ts' />
+
+declare module freedom.Transport {
+  // onData events.
+  export interface IncomingMessage {
+    tag:string;
+    data:ArrayBuffer;
+  }
+}
+
+declare module freedom {
+  export interface Transport {
+    // TODO(yangoon): define a type for signalling channels (proxy)
+    setup(name:string, proxy:any) : Promise<void>;
+    send(tag:string, data:ArrayBuffer) : Promise<void>;
+    close() : Promise<void>;
+
+    on(eventType:string, f:Function) : void;
+    on(eventType:'onData', f:(message:Transport.IncomingMessage) => void) : void;
+    on(eventType:'close', f:() => void) : void;
+  }
+}


### PR DESCRIPTION
I based this on the social.d.ts which seemed like it had the least redundancy and was the most recent file. I'm a little fuzzy on the finer points of TypeScript modules but this seems to work well for my work on moving  socks-rtc over to the transport API.
