### PR TITLE
fix promise typescript interface

### DIFF
--- a/interfaces/promise.d.ts
+++ b/interfaces/promise.d.ts
@@ -25,11 +25,13 @@ declare class Promise<T> {
   constructor(resolverFunction:(fulfill:(t?:T) => void,
                                 reject:(e:Error) => void) => void);
 
-  // then either returns subsiquent promise<T2> ...
+  // then()'s fulfill is always required, while reject is optional.
+  // The fulfill can either return subsequent promise<T2> ...
   then<T2>(fulfill:(t:T) => Promise<T2>, reject?:(e:Error) => Promise<T2>)
       : Promise<T2>;
-  // ... or the next fulfillment object directly.
-  then<T2>(fulfill?:(t:T) => T2, reject?:(e:Error) => T2) : Promise<T2>;
+  // ... or the next fulfillment object directly, or nothing at all.
+  then<T2>(fulfill:(t?:T) => T2, reject?:(e:Error) => T2) : Promise<T2>;
+  then<T2>(fulfill:(t?:T) => void, reject?:(e:Error) => void) : Promise<T2>;
 
   catch(catchFn:(e:Error) => Promise<T>) : Promise<T>;
   catch(catchFn:(e:Error) => T) : Promise<T>;


### PR DESCRIPTION
Compile errors while I was using `Promise.all`.

`Thenable`'s .then was conflicting with `Promise`'s .then. This fixes how the then's fulfill is actually mandatory, and also that it doesn't have to return anything.

Also, why is the promise interface in _freedom-typescript-api_? Promises/A+ is a more general spec, and should probably go in DefinitelyTyped at some point..
