### PR TITLE
Allow Promise.reject to be treated as returning Promise<void>

### DIFF
--- a/interfaces/promise.d.ts
+++ b/interfaces/promise.d.ts
@@ -42,6 +42,8 @@ declare class Promise<T> {
   static resolve() : Promise<void>;
 
   static reject<T>(e:Error) : Promise<T>;
+  // Allow casting of Promise.reject to Promise<void>.
+  static reject() : Promise<void>;
 
   static all<T>(promiseArray:Thenable<T>[]) : Promise<T>;
   static race<T>(...args:Thenable<T>[]) : Promise<T>;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-typescript-api",
   "description": "TypeScript Interface for Freedom",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/freedomjs/typescript-api"


### PR DESCRIPTION
Allow Promise.reject to be treated as returning `Promise<void>`

Tested by verifying that typescript now allows functions that return `Promise<void>` to return `Promise.reject()`
