### PR TITLE
More typescript comments and cleanup

### DIFF
--- a/interfaces/freedom.d.ts
+++ b/interfaces/freedom.d.ts
@@ -46,8 +46,8 @@ declare module freedom {
 
   // Communicate with the parent module. If this is the outer-page, then
   // communicates with the root module.
-  function on(eventType:string, f:Function) : void
-  function emit(eventType:string, value:Object) : void
+  function on(eventType:string, eventHandler:Function) : void
+  function emit(eventType:string, value :Object) : void
 }
 
 interface Window {

--- a/interfaces/freedom.d.ts
+++ b/interfaces/freedom.d.ts
@@ -1,6 +1,16 @@
 /// <reference path='../../third_party/promise/promise.d.ts' />
 
+// Common on/emit for message passing interfaces.
+interface OnAndEmit {
+  on(eventType:string, handler:Function) : void;
+  emit(eventType:string, value:Object) : void;
+}
+
 declare module freedom {
+  // The freedom object's on/emit communicate with the parent module. If this is
+  // the outer-page, then on/emit communicate with the root module.
+  function on(eventType:string, eventHandler:Function) : void
+  function emit(eventType:string, value :Object) : void
 
   /*
   // for freedom 0.5, the contextual freedom code that loads up the module
@@ -10,26 +20,31 @@ declare module freedom {
   }
   */
 
-  // Corresponds to Freedom object of type `proxy`.
-  interface ProxyEventInterface {
-    on(eventType:string, handler:Function) : void;
-    emit(eventType:string, handler:Function) : void;
-  }
-  // Specification for a channel.
-  interface ChannelSpecifier {
-    channel     :ProxyEventInterface;  // How to communicate over this channel.
-    identifier  :string;  // identifier for the created channel
-  }
+  // See |Core_unprivileged| in |core.unprivileged.js|
   interface Core {
     // Create a new channel which which to communicate between modules.
     createChannel() : Promise<ChannelSpecifier>;
-    // Given a string-identifier for a channel, create a proxy event interface
-    // for it.
-    bindChannel(identifier:string) : Promise<ProxyEventInterface>;
+    // Given an ChannelEndpointIdentifier for a channel, create a proxy event
+    // interface for it.
+    bindChannel(identifier:ChannelEndpointIdentifier) : Promise<Channel>;
     // Returns the list of identifiers describing the dependency path.
     getId() : string[];
   }
   function core() : Core
+
+  // Channels are ways that freedom modules can send each other messages.
+  interface Channel extends OnAndEmit {
+    close() : void;
+  }
+  // Specification for a channel.
+  interface ChannelSpecifier {
+    channel     :Channel;  // How to communicate over this channel.
+    identifier  :ChannelEndpointIdentifier;
+  }
+  // An endpoint identifier for a channel. Can be passed over a freedom message-
+  // passing boundary.  It is used to create a channel to the freedom module
+  // that called createChannel and created this ChannelSpecifier.
+  interface ChannelEndpointIdentifier {}
 
   // This is the first argument given to a core provider's constructor. It is an
   // object that describes the parent module the core provider instance has been
@@ -43,14 +58,14 @@ declare module freedom {
       removeEventListener :(s:string, f:Function, b:boolean) => void;
     };
   }
-
-  // Communicate with the parent module. If this is the outer-page, then
-  // communicates with the root module.
-  function on(eventType:string, eventHandler:Function) : void
-  function emit(eventType:string, value :Object) : void
 }
 
 interface Window {
-  // The freedom config call registers
+  // The freedom config variable can be set in the window to let an application
+  // register additional core-providers. When Freedom starts up, if the
+  // |freedomcfg| var is defined, it will call it passing it the internal core-
+  // provider registration function. |providerName| should be a name of a core-
+  // provider as defined in |freedom/interface/core.js|, and the function-
+  // argument should be a class that meets that interface of |providerName|.
   freedomcfg(register:(providerName:string, classFn:Function) => void) : void;
 }

--- a/interfaces/peer-connection.d.ts
+++ b/interfaces/peer-connection.d.ts
@@ -1,8 +1,8 @@
-// TODO: Make these actually typed, and probably shove into freedom.
+// This documents the peerconnection core provider who's freedom-interface is
+// here: https://github.com/freedomjs/freedom/blob/master/interface/core.js
 
-// Reference:
-// https://github.com/UWNetworksLab/freedom/blob/master/interface/core.js
 /// <reference path='../../third_party/promise/promise.d.ts' />
+/// <reference path='freedom.d.ts' />
 
 declare module freedom.PeerConnection {
   interface ChannelInfo {
@@ -24,29 +24,32 @@ declare module freedom {
 
   // TODO: add issue for `onOpenDataChannel` to have return value field named
   // `channelLabel`, not `channelId`, to be consistent with `onReceived`.
-  class PeerConnection {
+  interface PeerConnection {
     // Setup a new peer connection.
-    setup(freedomChannelId:string, // Freedom signalling channel id.
-            debugName:string,  // used for debugging messages.
-            stunServers:string[])
-          : Promise<void>;
+    setup(freedomChannelId  :freedom.ChannelEndpointIdentifier,
+          debugName:string,  // used for debugging messages.
+          stunServers:string[])
+        : Promise<void>;
 
     // Send a message, if the channelLabel does not exist, it is created. TODO:
     // clarify semantics: does a channel created by this class raise an
     // `onOpenDataChannel` event?
     send(d:PeerConnection.ChannelMessage) : void;
-    openDataChannel(channelLabel:string) : void;
-    closeDataChannel(channelLabel:string) : void;
-    close() : void;
+    openDataChannel(channelLabel:string) : Promise<void>;
+    closeDataChannel(channelLabel:string) : Promise<void>;
+    close() : Promise<void>;
 
     // Generic freedom `on` handler.
     on(t:string, f:Function) : void;
-    on(t:'onOpenDataChannel', f:(d:PeerConnection.ChannelInfo) => void) : void;
     on(t:'onReceived', f:(d:PeerConnection.ChannelMessage) => void) : void;
     on(t:'onClose', f:() => void) : void;
+    // The |onOpenDataChannel| and |onCloseDataChannel| events happen when the
+    // remote peer opens or closes a connection to this peer-connection.
+    on(t:'onOpenDataChannel', f:(d:PeerConnection.ChannelInfo) => void) : void;
     on(t:'onCloseDataChannel', f:(d:PeerConnection.ChannelInfo) => void) : void;
 
-    // Given a channel Label, returns the buffered amount on that channel.
+    // Given a channel Label, returns the buffered amount on that channel. TODO:
+    // this should probably not be exposed. buffering should be handled inside.
     getBufferedAmount(string) : Promise<number>;
   }
 }

--- a/interfaces/peer-connection.d.ts
+++ b/interfaces/peer-connection.d.ts
@@ -50,6 +50,6 @@ declare module freedom {
 
     // Given a channel Label, returns the buffered amount on that channel. TODO:
     // this should probably not be exposed. buffering should be handled inside.
-    getBufferedAmount(string) : Promise<number>;
+    getBufferedAmount(channelLabel:string) : Promise<number>;
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,4 +31,3 @@
   "author": "Lucas Dixon <ldixon@google.com> (https://github.com/iislucas)",
   "license": "Apache2"
 }
-

--- a/package.json
+++ b/package.json
@@ -31,3 +31,4 @@
   "author": "Lucas Dixon <ldixon@google.com> (https://github.com/iislucas)",
   "license": "Apache2"
 }
+


### PR DESCRIPTION
- More comments for freedom-apis
- Abstracted out on/emit interface. 
- Treating ChannelEndpointIdentifier as an empty interface; it at least has its own label now. Sadly typescript doesn't support type-abstraction. 
- Added close to Channel objects. 
